### PR TITLE
Define the function on '*tunnelRelic.Tunnel'

### DIFF
--- a/tunnel_relic.go
+++ b/tunnel_relic.go
@@ -44,7 +44,7 @@ func NewTunnel(Account string, APIKey string, EventName string, send int, sendBu
 
 }
 
-func NewTransaction() map[string]interface{} {
+func (relic *Tunnel) NewTransaction() map[string]interface{} {
 	newRelicTransaction := make(map[string]interface{})
 
 	if hostname, err := os.Hostname(); err == nil {


### PR DESCRIPTION
Hey @ericdmann I was getting the following error when following the example in the Readme. This patch is working for me.

```
gopherTunnel.NewTransaction undefined (type *tunnelRelic.Tunnel has no field or method NewTransaction)
```
